### PR TITLE
Fixes Source.find to require token

### DIFF
--- a/lib/patient_zero/source.rb
+++ b/lib/patient_zero/source.rb
@@ -18,7 +18,7 @@ module PatientZero
       end
     end
 
-    def self.find source_id, token=Authorization.token
+    def self.find source_id, token
       response = get '/mobile/api/v1/sources/show/', id: source_id, client_token: token
       new response['source'], token
     rescue Error => e

--- a/lib/patient_zero/version.rb
+++ b/lib/patient_zero/version.rb
@@ -1,3 +1,3 @@
 module PatientZero
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/patient_zero/source_spec.rb
+++ b/spec/patient_zero/source_spec.rb
@@ -48,21 +48,17 @@ module PatientZero
       end
       it 'calls the sources show api' do
         expect(Client.connection).to receive(:get).with('/mobile/api/v1/sources/show/', anything)
-        Source.find id
-      end
-      it 'calls Authorization.token if no token is passed in' do
-        expect(Authorization).to receive(:token)
-        Source.find id
+        Source.find id, token
       end
       context 'when the source exists' do
         it 'returns a source' do
-          expect(Source.find(id).id).to eq source.id
+          expect(Source.find(id, token).id).to eq source.id
         end
       end
       context 'when no source exists' do
         it 'throws an PatientZero::Error' do
           allow(Client).to receive(:get).and_raise Error, 'The source could not be found. Please check your inputs.'
-          expect{ Source.find id }.to raise_error PatientZero::NotFoundError
+          expect{ Source.find id, token }.to raise_error PatientZero::NotFoundError
         end
       end
     end


### PR DESCRIPTION
_this PR does the following_

* Removes the default token for Source.find, no longer pulls in the high level client token by default, requires one to be passed
* Bumps gem version to 0.2.1