### PR TITLE
Adds Tumblr Analytics, Fixes Potential Bugs

### DIFF
--- a/lib/patient_zero/analytics.rb
+++ b/lib/patient_zero/analytics.rb
@@ -2,12 +2,14 @@ require 'patient_zero/analytics/base'
 require 'patient_zero/analytics/twitter'
 require 'patient_zero/analytics/facebook'
 require 'patient_zero/analytics/instagram'
+require 'patient_zero/analytics/tumblr'
 
 module PatientZero
   module Analytics
     SOURCE_TYPES = {'twitter' => Twitter,
                     'facebook' => Facebook,
-                    'instagram' => Instagram}
+                    'instagram' => Instagram,
+                    'tumblr' => Tumblr}
 
     def self.for_platform platform, params={}
       SOURCE_TYPES[platform].new params

--- a/lib/patient_zero/analytics.rb
+++ b/lib/patient_zero/analytics.rb
@@ -13,6 +13,8 @@ module PatientZero
 
     def self.for_platform platform, params={}
       SOURCE_TYPES[platform].new params
+    rescue NoMethodError
+      nil
     end
   end
 end

--- a/lib/patient_zero/analytics/base.rb
+++ b/lib/patient_zero/analytics/base.rb
@@ -24,6 +24,10 @@ module PatientZero
         analytical_data['messages'].map { |message| Message.for_platform message['platform'], message }
       end
 
+      def total_posts
+        messages.count
+      end
+
       private
 
       def analytical_data

--- a/lib/patient_zero/analytics/base.rb
+++ b/lib/patient_zero/analytics/base.rb
@@ -21,7 +21,7 @@ module PatientZero
       end
 
       def messages
-        analytical_data['messages'].map { |message| Message.for_platform message['platform'], message }
+        analytical_data['messages'].map { |message| Message.for_platform message['platform'], message }.compact
       end
 
       def total_posts

--- a/lib/patient_zero/analytics/tumblr.rb
+++ b/lib/patient_zero/analytics/tumblr.rb
@@ -1,0 +1,25 @@
+module PatientZero
+  module Analytics
+    class Tumblr < Base
+      def messages
+        []
+      end
+
+      def total_posts
+        analytical_data.fetch('total_posts').to_i
+      end
+
+      def engagements
+        likes
+      end
+
+      def followers
+        analytical_data.fetch('total_followers').to_i
+      end
+
+      def likes
+        analytical_data.fetch('total_likes').to_i
+      end
+    end
+  end
+end

--- a/lib/patient_zero/message.rb
+++ b/lib/patient_zero/message.rb
@@ -11,6 +11,8 @@ module PatientZero
 
     def self.for_platform platform, params={}
       SOURCE_TYPES[platform].new params
+    rescue NoMethodError
+      nil
     end
   end
 end

--- a/lib/patient_zero/version.rb
+++ b/lib/patient_zero/version.rb
@@ -1,3 +1,3 @@
 module PatientZero
-  VERSION = '0.5.4'
+  VERSION = '0.5.5'
 end

--- a/spec/patient_zero/analytics/base_spec.rb
+++ b/spec/patient_zero/analytics/base_spec.rb
@@ -6,7 +6,7 @@ module PatientZero
       let(:source_id) { "12345##{platform}#1234567890" }
       let(:name) { 'account_name' }
       let(:platform) { 'account_type' }
-      let(:messages) { [ { 'platform' => 'FB' } ] }
+      let(:messages) { [ { 'platform' => 'FB' }, { 'platform' => '??' } ] }
       let(:token) { 'token-shmoken' }
       let(:analytical_data) { { 'stats' => [ { 'id' => source_id, 'platform' => platform, 'name' => name, 'messages' => messages } ] } }
       subject(:analytics_base) { Base.new token: token, source_id: source_id }

--- a/spec/patient_zero/analytics/base_spec.rb
+++ b/spec/patient_zero/analytics/base_spec.rb
@@ -49,6 +49,12 @@ module PatientZero
           end
         end
       end
+
+      describe '#total_posts' do
+        it 'returns the count of messages' do
+          expect(analytics_base.total_posts).to be 1
+        end
+      end
     end
   end
 end

--- a/spec/patient_zero/analytics/tumblr_spec.rb
+++ b/spec/patient_zero/analytics/tumblr_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module PatientZero
+  module Analytics
+    describe Tumblr do
+      let(:source_id) { "12345##{platform}#1234567890" }
+      let(:platform) { 'tumblr' }
+      let(:token) { 'token-shmoken' }
+      let(:followers) { '26' }
+      let(:likes) { '89' }
+      let(:posts) { '45' }
+      let(:analytical_data) { { 'total_posts'=>posts, 'total_followers'=>followers, 'total_likes'=>likes } }
+      let(:tumblr_analytics) { Tumblr.new token: token, source_id: source_id }
+      before{ allow(tumblr_analytics).to receive(:analytical_data).and_return analytical_data }
+
+      describe '#messages' do
+        it 'returns an empty array' do
+          expect(tumblr_analytics.messages).to eq []
+        end
+      end
+
+      describe '#total_posts' do
+        it 'returns the number of posts from the analytical_data hash' do
+          expect(tumblr_analytics.total_posts).to eq posts.to_i
+        end
+      end
+
+      describe '#engagements' do
+        it 'returns the sum of likes from the analytical_data hash' do
+          expect(tumblr_analytics.engagements).to eq likes.to_i
+        end
+      end
+
+      describe '#followers' do
+        it 'returns the number of followers from the analytical_data hash' do
+          expect(tumblr_analytics.followers).to eq followers.to_i
+        end
+      end
+
+      describe '#likes' do
+        it 'returns the number of likes from the analytical_data hash' do
+          expect(tumblr_analytics.likes).to eq likes.to_i
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
_this PR does the following_

* Adds Analytics::Tumblr Class with tests
* Adds total_posts method so we can get the total number of posts for a source
* Adds a way to skip and return nils for bad message types
* Adds a way to return nil for a bad analytic type
* Bumps version to 0.5.5
