### PR TITLE
Adds Source Creation URL Method

### DIFF
--- a/lib/patient_zero/errors.rb
+++ b/lib/patient_zero/errors.rb
@@ -1,4 +1,5 @@
 module PatientZero
   class Error < StandardError; end
   class NotFoundError < Error; end
+  class InvalidPlatformError < Error; end
 end

--- a/lib/patient_zero/source.rb
+++ b/lib/patient_zero/source.rb
@@ -28,6 +28,13 @@ module PatientZero
       raise NotFoundError, e
     end
 
+    def self.creation_url platform, token=Authorization.token, reference_id=nil
+      response = connection.get("/mobile/api/v1/sources/#{platform}/authenticate", client_token: token, reference_id: reference_id)
+      creation_url = response.headers.fetch :location
+      raise InvalidPlatformError, creation_url.split('error=').last if creation_url.include? 'error'
+      creation_url
+    end
+
     def platform_id
       id.split('#').last
     end

--- a/lib/patient_zero/version.rb
+++ b/lib/patient_zero/version.rb
@@ -1,3 +1,3 @@
 module PatientZero
-  VERSION = '0.5.7'
+  VERSION = '0.5.8'
 end

--- a/spec/patient_zero/source_spec.rb
+++ b/spec/patient_zero/source_spec.rb
@@ -65,6 +65,29 @@ module PatientZero
       end
     end
 
+    describe '.creation_url' do
+      let(:platform) { 'facebook' }
+      let(:url) { 'http://something-something.dangerzone.com' }
+      let(:creation_url_response) { double :creation_url_response, headers: { location: url } }
+      before{ allow(Source.connection).to receive(:get).with("/mobile/api/v1/sources/#{platform}/authenticate", anything).and_return creation_url_response }
+      it 'calls the sources authentication api' do
+        expect(Source.connection).to receive(:get).with("/mobile/api/v1/sources/#{platform}/authenticate", anything)
+        Source.creation_url platform, token, 678
+      end
+      context 'when using a valid platform name' do
+        it 'returns the valid url' do
+          expect(Source.creation_url platform, token, 678).to eq url
+        end
+      end
+      context 'when using an invalid platform name' do
+        let(:platform) { 'myspace' }
+        let(:url) { '"https://app.viralheat.com?error=Invalid platform Myspace"' }
+        it 'raises an InvalidPlatformError' do
+          expect{Source.creation_url platform, token, 678}.to raise_error InvalidPlatformError
+        end
+      end
+    end
+
     describe '#platform_id' do
       it 'returns the number at the end of the id' do
         expect(source.platform_id).to eq '1234567890'


### PR DESCRIPTION
_this PR does the following_

* Adds InvalidPlatformError to the gem
* Adds method to get URL for adding a source by platform
* Returns an InvalidPlatformError if the platform passed is invalid
* Bumps Gem version 0.5.8