### PR TITLE
fixes an access error when to getting oauth url

### DIFF
--- a/lib/patient_zero/source.rb
+++ b/lib/patient_zero/source.rb
@@ -30,7 +30,7 @@ module PatientZero
 
     def self.creation_url platform, token=Authorization.token, reference_id=nil
       response = connection.get("/mobile/api/v1/sources/#{platform}/authenticate", client_token: token, reference_id: reference_id)
-      creation_url = response.headers.fetch :location
+      creation_url = response.headers.fetch 'location'
       raise InvalidPlatformError, creation_url.split('error=').last if creation_url.include? 'error'
       creation_url
     end

--- a/lib/patient_zero/version.rb
+++ b/lib/patient_zero/version.rb
@@ -1,3 +1,3 @@
 module PatientZero
-  VERSION = '0.5.8'
+  VERSION = '0.5.9'
 end

--- a/spec/patient_zero/source_spec.rb
+++ b/spec/patient_zero/source_spec.rb
@@ -68,7 +68,7 @@ module PatientZero
     describe '.creation_url' do
       let(:platform) { 'facebook' }
       let(:url) { 'http://something-something.dangerzone.com' }
-      let(:creation_url_response) { double :creation_url_response, headers: { location: url } }
+      let(:creation_url_response) { double :creation_url_response, headers: { 'location' => url } }
       before{ allow(Source.connection).to receive(:get).with("/mobile/api/v1/sources/#{platform}/authenticate", anything).and_return creation_url_response }
       it 'calls the sources authentication api' do
         expect(Source.connection).to receive(:get).with("/mobile/api/v1/sources/#{platform}/authenticate", anything)


### PR DESCRIPTION
when trying to access the location variable in the response back from the oauth_url look up, it fails accessing it as a symbol in certain environments. Needs to access this data as a string.