### PR TITLE
Adds Source#children method

### DIFF
--- a/lib/patient_zero/source.rb
+++ b/lib/patient_zero/source.rb
@@ -51,6 +51,13 @@ module PatientZero
       end
     end
 
+    def children
+      response = get '/mobile/api/v1/sources/linked_sources', social_object_uid: id, client_token: token
+      response['linked_sources'].map do |source_attributes|
+        Source.new(source_attributes.merge 'token' => token) unless source_attributes["id"] == id
+      end.compact
+    end
+
     def analytics start_date: nil, end_date: nil
       @analytics ||= {}
       @analytics["#{start_date}#{end_date}"] ||= Analytics.for_platform platform, token: token, source_id: id, start_date: start_date, end_date: end_date

--- a/lib/patient_zero/version.rb
+++ b/lib/patient_zero/version.rb
@@ -1,3 +1,3 @@
 module PatientZero
-  VERSION = '0.5.9'
+  VERSION = '0.5.10'
 end

--- a/spec/patient_zero/source_spec.rb
+++ b/spec/patient_zero/source_spec.rb
@@ -81,7 +81,7 @@ module PatientZero
       end
       context 'when using an invalid platform name' do
         let(:platform) { 'myspace' }
-        let(:url) { '"https://app.viralheat.com?error=Invalid platform Myspace"' }
+        let(:url) { 'https://app.viralheat.com?error=Invalid platform Myspace' }
         it 'raises an InvalidPlatformError' do
           expect{Source.creation_url platform, token, 678}.to raise_error InvalidPlatformError
         end

--- a/spec/patient_zero/source_spec.rb
+++ b/spec/patient_zero/source_spec.rb
@@ -119,6 +119,36 @@ module PatientZero
       end
     end
 
+    describe '#children' do
+      let(:sources) do
+        [ {'id'=> id,
+           'name' => 'account_name',
+           'is_invalid' => false,
+           'is_tracked' => true,
+           'platform' => 'facebook',
+           'delete_id' => id },
+          {'id'=> 'source_id',
+           'name' => 'account_page',
+           'is_invalid' => false,
+           'is_tracked' => true,
+           'platform' => 'facebook',
+           'delete_id' => id } ]
+      end
+      let(:children_response) { response_with_body linked_sources: sources }
+      before{ allow(Source.connection).to receive(:get).with('/mobile/api/v1/sources/linked_sources', anything).and_return children_response }
+      context 'when the source has children' do
+        it 'returns an array of sources that does not contain itself' do
+          expect(source.children.count).to be 1
+        end
+      end
+      context 'when the source has no children' do
+        let(:sources) { [] }
+        it 'returns an empty array' do
+          expect(source.children).to be_empty
+        end
+      end
+    end
+
     describe '#analytics' do
       it 'calls Analytics.for_platorm to create an analytics object' do
         expect(Analytics).to receive(:for_platform).with(source.platform, { token: source.token, source_id: source.id, start_date: nil, end_date: nil })


### PR DESCRIPTION
This allows the lookup of children sources for the instance of a source, if it doesn't have any, it will return an empty array.

Tested. 

Also fixes a slight string typo in the source tests